### PR TITLE
Fixed PropLessOrEqualXY_C to add the right rule.

### DIFF
--- a/choco-solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
+++ b/choco-solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
@@ -108,7 +108,7 @@ public final class PropLessOrEqualXY_C extends Propagator<IntVar> {
         if (var.equals(x)) {
             newrules |=ruleStore.addLowerBoundRule(y);
         } else if (var.equals(y)) {
-            newrules |=ruleStore.addUpperBoundRule(y);
+            newrules |=ruleStore.addLowerBoundRule(x);
         } else {
             newrules |=super.why(ruleStore, var, evt, value);
         }


### PR DESCRIPTION
For example, the following code should find 3 solutions but currently finds none.

```java
        Solver s = new Solver();

        IntVar i = VF.enumerated("i", -1, 1, s);
        IntVar j = VF.enumerated("j", -1, 1, s);

        s.post(ICF.arithm(j, "+", i, "<", 1));
        LCF.ifThen(ICF.arithm(i, "=", -1), ICF.arithm(i, "!=", -1));

        s.set(ISF.lexico_UB(j, i));

        Chatterbox.showDecisions(s);
        Chatterbox.showSolutions(s);
        Chatterbox.showContradiction(s);

        ExplanationFactory.CBJ.plugin(s, true, false);
        System.out.println(s.findAllSolutions());
```