### PR TITLE
Fixed BitsetArrayIntVarImpl::updateUpperBound adding spurious values to its delta

### DIFF
--- a/choco-solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
+++ b/choco-solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
@@ -493,7 +493,7 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
                 assert index >= 0 && VALUES[index] <= value;
                 if (reactOnRemoval) {
                     //BEWARE: this loop significantly decreases performances
-                    for (int i = ub; i > -1; i = INDICES.prevSetBit(i - 1)) {
+                    for (int i = ub; i >=0 && i > index; i = INDICES.prevSetBit(i - 1)) {
                         delta.add(VALUES[i], cause);
                     }
                 }


### PR DESCRIPTION
For example:

```java
public static void main(String[] args) throws Exception {
    Solver s = new Solver();
    IntVar i = VF.enumerated("i", new int[]{0,98,99}, s);
    IIntDeltaMonitor d= i.monitorDelta(Cause.Null);
    i.updateUpperBound(98, Cause.Null);
    d.freeze();
    d.forEachRemVal((IntProcedure) System.out::println);
    d.unfreeze();
}
```

This will print "99 98 0" even though the only removed value is 99.