### PR TITLE
RFC: Handling overflow in multiplication

### DIFF
--- a/choco-solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaive.java
+++ b/choco-solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaive.java
@@ -123,11 +123,14 @@ public class PropTimesNaive extends Propagator<IntVar> {
     public static int multiply(int a, int b) {
         if (a == 0 || b == 0)
             return 0;
-        int product = a * b;
-        int a2 = product / b;
-        if (a != a2)
-            throw new ArithmeticException("Overflow occurred from int " + a + " * " + b);
-        return product;
+        long product = (long) a * b;
+        if (product >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (product <= Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) product;
     }
 
     @Override


### PR DESCRIPTION
For example, consider the following program:

```java
Solver s = new Solver();
s.set(new Settings() {

    @Override
    public boolean enableTableSubstitution() {
        return false;
    }
});
IntVar i1 = VF.enumerated("i1", new int[]{1, 55000}, s);
IntVar i2 = VF.enumerated("i2", new int[]{1, 55000}, s);
IntVar i3 = VF.enumerated("i3", new int[]{1, 55000}, s);
s.post(ICF.times(i1, i2, i3));
```

This will throw the following overflow exception:

```
Exception in thread "main" java.lang.ArithmeticException: Overflow occurred from int 55000 * 55000
	at org.chocosolver.solver.constraints.ternary.PropTimesNaive.multiply(PropTimesNaive.java:129)
	at org.chocosolver.solver.constraints.ternary.PropTimesNaive.mul(PropTimesNaive.java:118)
	at org.chocosolver.solver.constraints.ternary.PropTimesNaive.propagate(PropTimesNaive.java:72)
	at org.chocosolver.solver.propagation.PropagationTrigger.execute(PropagationTrigger.java:196)
	at org.chocosolver.solver.propagation.PropagationTrigger.propagate(PropagationTrigger.java:152)
	at org.chocosolver.solver.propagation.hardcoded.SevenQueuesPropagatorEngine.propagate(SevenQueuesPropagatorEngine.java:157)
	at org.chocosolver.solver.search.loop.PropagateBasic.execute(PropagateBasic.java:47)
	at org.chocosolver.solver.search.loop.SearchLoop.initialize(SearchLoop.java:388)
	at org.chocosolver.solver.search.loop.SearchLoop.launch(SearchLoop.java:286)
	at org.chocosolver.solver.Solver.solve(Solver.java:1353)
	at org.chocosolver.solver.Solver.findSolution(Solver.java:1077)
```

But we should be able to handle the original program though.

I think I fixed the overflow issue, but I don't fully understand the consequence of the change.